### PR TITLE
inlcude mention of --rate-limit flag for the influx write command 

### DIFF
--- a/docs/part-3/writing-and-querying-data.md
+++ b/docs/part-3/writing-and-querying-data.md
@@ -326,6 +326,9 @@ For our simple example, we have:
 We use the following command to write the data to InfluxDB: 
 `influx write dryrun  -b mybucket -f ~/path/to/writeCSV.csv --header "#datatype dateTime:2006-01-02T15:04:05Z07:00,tag,tag,double,measurement" --skip-header`
 
+Finally, it's worth being aware of the `--rate-limit` flag. This flag allows you to throttole your write rate to avoid exceeding write rate limits. We append the previous command to include the `--rate-limit` flag, for demonstation purposes. This example CSV doen't require the use of the `--rate-limit` flag, but to write any signifcant CSV to InfluxDB the use of that flag is recommended. 
+`influx write dryrun  -b mybucket -f ~/path/to/writeCSV.csv --header "#datatype dateTime:2006-01-02T15:04:05Z07:00,tag,tag,double,measurement" --skip-header --rate-limit "1MB/s"`
+
 
 #### A Significant Example
 

--- a/docs/part-3/writing-and-querying-data.md
+++ b/docs/part-3/writing-and-querying-data.md
@@ -326,7 +326,7 @@ For our simple example, we have:
 We use the following command to write the data to InfluxDB: 
 `influx write dryrun  -b mybucket -f ~/path/to/writeCSV.csv --header "#datatype dateTime:2006-01-02T15:04:05Z07:00,tag,tag,double,measurement" --skip-header`
 
-Finally, it's worth being aware of the `--rate-limit` flag. This flag allows you to throttole your write rate to avoid exceeding write rate limits. We append the previous command to include the `--rate-limit` flag, for demonstation purposes. This example CSV doen't require the use of the `--rate-limit` flag, but to write any signifcant CSV to InfluxDB the use of that flag is recommended. 
+Finally, it's worth being aware of the `--rate-limit` flag. This flag allows you to throttole your write rate to avoid exceeding write rate limits. We append the previous command to include the `--rate-limit` flag, for demonstration purposes. This example CSV doen't require the use of the `--rate-limit` flag, but to write any signifcant CSV to InfluxDB the use of that flag is recommended. 
 `influx write dryrun  -b mybucket -f ~/path/to/writeCSV.csv --header "#datatype dateTime:2006-01-02T15:04:05Z07:00,tag,tag,double,measurement" --skip-header --rate-limit "1MB/s"`
 
 


### PR DESCRIPTION
closes #13

Finally, it's worth being aware of the `--rate-limit` flag. This flag allows you to throttole your write rate to avoid exceeding write rate limits. We append the previous command to include the `--rate-limit` flag, for demonstation purposes. This example CSV doen't require the use of the `--rate-limit` flag, but to write any signifcant CSV to InfluxDB the use of that flag is recommended. 
`influx write dryrun  -b mybucket -f ~/path/to/writeCSV.csv --header "#datatype dateTime:2006-01-02T15:04:05Z07:00,tag,tag,double,measurement" --skip-header --rate-limit "1MB/s"`

